### PR TITLE
Added correct escaping of single quotes in values of a dbf db field

### DIFF
--- a/sqlite3-dbf.h
+++ b/sqlite3-dbf.h
@@ -144,6 +144,9 @@ static void safeprintbuf(const char *buf, const size_t inputsize)
     t = targetbuf;
     for(s = buf; s <= lastchar; s++) {
 	switch(*s) {
+	case '\'':
+	    *t++ = '\'';
+	    *t++ = '\'';
 	case '\\':
 	    *t++ = '\\';
 	    *t++ = '\\';


### PR DESCRIPTION
I had to use your tool for a project, but it didn't produce valid insert statements from my dbf file. I found out that it's due to the missing escpaing of single quotes.